### PR TITLE
stream: Change unwrap to ConnectionFailed error

### DIFF
--- a/src/stream.rs
+++ b/src/stream.rs
@@ -491,7 +491,7 @@ pub(crate) fn connect_host(
                 "{}",
                 proxy.connect(hostname, port, &unit.agent.config.user_agent)
             )
-            .unwrap();
+            .map_err(|err| ErrorKind::ConnectionFailed.msg("Connect error").src(err))?;
             stream.flush()?;
 
             let s = stream.try_clone()?;


### PR DESCRIPTION
When writing to socket, the resulting write may fail and return errno 101 "Network Unavailable" and crashing the library (or the dependant of the library). Therefore, if we receive an error, it will be converted to a ConnectionFailed error so that it's handled properly